### PR TITLE
Removed rewind logic for IBD

### DIFF
--- a/src/Blockcore.Indexer.Core/Sync/SyncTasks/BlockIndexer.cs
+++ b/src/Blockcore.Indexer.Core/Sync/SyncTasks/BlockIndexer.cs
@@ -309,8 +309,6 @@ namespace Blockcore.Indexer.Core.Sync.SyncTasks
 
                log.LogDebug($"Indexer - Indexing completed in {watch.Elapsed}");
 
-               await BlockRewindOperation.UpdateUnspentOutputFromRewindWithMissingDetailsAsync(mongoData);
-
                Abort = true;
                return true;
             }

--- a/src/Blockcore.Indexer.Core/Sync/SyncTasks/BlockIndexer.cs
+++ b/src/Blockcore.Indexer.Core/Sync/SyncTasks/BlockIndexer.cs
@@ -309,6 +309,8 @@ namespace Blockcore.Indexer.Core.Sync.SyncTasks
 
                log.LogDebug($"Indexer - Indexing completed in {watch.Elapsed}");
 
+               await BlockRewindOperation.UpdateUnspentOutputFromRewindWithMissingDetailsAsync(mongoData);
+
                Abort = true;
                return true;
             }


### PR DESCRIPTION
The rewind in IBD is really trying to cope with a failure in the infrastructure rather than handle a real fork in the chain with a longer tip. it's better to wipe the db and start over than add complex logic that we don't really need.