### PR TITLE
return correct conf count for trx api call

### DIFF
--- a/src/Blockcore.Indexer.Core/Storage/Mongo/MongoData.cs
+++ b/src/Blockcore.Indexer.Core/Storage/Mongo/MongoData.cs
@@ -311,7 +311,7 @@ namespace Blockcore.Indexer.Core.Storage.Mongo
             BlockHash = blk.BlockHash,
             Timestamp = blk.BlockTime,
             TransactionHash = trx.TransactionId,
-            Confirmations = current.BlockIndex - trx.BlockIndex
+            Confirmations = current.BlockIndex + 1 - trx.BlockIndex
          };
       }
 


### PR DESCRIPTION
closes: #124 

To get the correct number of confirmations we have to add one more block to the result of current height - the block a trx got confirmed in. this is becuase we consider the block that transaction was confirmed in as 1 confirmation