### PR TITLE
Find outputs in mempool and remove them from unspent outputs api call

### DIFF
--- a/src/Blockcore.Indexer.Core/Storage/Mongo/MongoData.cs
+++ b/src/Blockcore.Indexer.Core/Storage/Mongo/MongoData.cs
@@ -692,10 +692,6 @@ namespace Blockcore.Indexer.Core.Storage.Mongo
             .Match(m => m.AddressInputs.Contains(address) || m.AddressOutputs.Contains(address))
             .ToList();
 
-         // IQueryable<MempoolTable> mempoolForAddress = mongoDb.Mempool
-         //    .AsQueryable()
-         //    .Where(m => m.AddressInputs.Contains(address) || m.AddressOutputs.Contains(address));
-
          foreach (MempoolTable mempool in mempoolForAddress)
          {
             var bag = new MapMempoolAddressBag { Mempool = mempool };

--- a/src/Blockcore.Indexer.Core/Storage/Mongo/MongoData.cs
+++ b/src/Blockcore.Indexer.Core/Storage/Mongo/MongoData.cs
@@ -1136,10 +1136,12 @@ namespace Blockcore.Indexer.Core.Storage.Mongo
          // remove any outputs that have been spent in the mempool
          mempoolItems?.ForEach(mp => mp.Mempool.Inputs.ForEach(input =>
          {
-            Outpoint item = unspentOutputs.FirstOrDefault(w => w.ToString() == input.Outpoint.ToString());
-            if (item != null)
-               unspentOutputs.Remove(item);
-
+            if (input.Address == address)
+            {
+               Outpoint item = unspentOutputs.FirstOrDefault(w => w.ToString() == input.Outpoint.ToString());
+               if (item != null)
+                  unspentOutputs.Remove(item);
+            }
          }));
 
          var results = await mongoDb.OutputTable.Aggregate()

--- a/src/Blockcore.Indexer.Tests/Storage/Mongo/MongoDataTests.cs
+++ b/src/Blockcore.Indexer.Tests/Storage/Mongo/MongoDataTests.cs
@@ -1,0 +1,117 @@
+using System;
+using Blockcore.Consensus;
+using Blockcore.Consensus.ScriptInfo;
+using Blockcore.Indexer.Core.Client;
+using Blockcore.Indexer.Core.Crypto;
+using Blockcore.Indexer.Core.Operations.Types;
+using Blockcore.Indexer.Core.Settings;
+using Blockcore.Indexer.Core.Storage;
+using Blockcore.Indexer.Core.Storage.Mongo;
+using Blockcore.Indexer.Core.Storage.Mongo.Types;
+using Blockcore.Networks;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Blockcore.Indexer.Tests.Storage.Mongo;
+
+public class MongoDataTests
+{
+   readonly MongoData sut;
+
+   static readonly Random Random = new();
+   private static string NewRandomString => Guid.NewGuid().ToString();
+   private static int NewRandomInt32 => Random.Next();
+   private static long NewRandomInt64  => Random.NextInt64();
+
+   readonly IndexerSettings indexSettings;
+   ScriptOutputInfo scriptOutputInfo;
+   readonly MongodbMock mongodbMock;
+   GlobalState globalState;
+
+   public MongoDataTests()
+   {
+      var indexSettingsMock = new Mock<IOptions<IndexerSettings>>();
+
+      indexSettings = new IndexerSettings
+      {
+         RpcPassword = NewRandomString,
+         RpcUser = NewRandomString,
+         RpcAccessPort = NewRandomInt32,
+         RpcDomain = NewRandomString,
+      };
+
+      indexSettingsMock.Setup(_ => _.Value)
+         .Returns(() => indexSettings);
+      var chainSetting = new Mock<IOptions<ChainSettings>>();
+
+      chainSetting.SetupGet(_ => _.Value)
+         .Returns(new ChainSettings { Symbol = NewRandomString });
+
+      var networkSettings = new Mock<IOptions<NetworkSettings>>();
+
+      networkSettings.Setup(_ => _.Value)
+         .Returns(new NetworkSettings
+         {
+            APIPort = NewRandomInt32,
+            NetworkConsensusFactoryType = typeof(ConsensusFactory).AssemblyQualifiedName,
+            NetworkWitnessPrefix = "coin"
+         });
+
+      var syncConnection = new SyncConnection(indexSettingsMock.Object,
+         chainSetting.Object, networkSettings.Object);
+
+      globalState = new GlobalState();
+
+      var cryptoClientFactory = new Mock<ICryptoClientFactory>();
+
+
+      var scriptInterpeter = new Mock<IScriptInterpeter>();
+
+      scriptInterpeter.Setup(_ => _.InterpretScript(It.IsAny<Network>(), It.IsAny<Script>()))
+         .Returns(() => scriptOutputInfo);
+
+      mongodbMock = new MongodbMock();
+
+      sut = new MongoData(null, syncConnection, chainSetting.Object, globalState,
+            new MapMongoBlockToStorageBlock(),
+            cryptoClientFactory.Object, scriptInterpeter.Object, mongodbMock.MongoDatabaseObject,
+            mongodbMock.MongoDbObject, new Mock<IBlockRewindOperation>().Object);
+   }
+
+   // TODO dan: fix this test
+   // [Fact] 
+   public void GetUnspentTransactionsByAddressWithItemsInMempool()
+   {
+      var addressMain = NewRandomString;
+      var addressSecondery = NewRandomString;
+
+      globalState.StoreTip = new Core.Storage.Types.SyncBlockInfo { BlockIndex = 100 };
+
+      var outpoint1 = new Outpoint { OutputIndex = NewRandomInt32, TransactionId = NewRandomString };
+      var unspentOutput1 = new UnspentOutputTable { Outpoint = outpoint1, Address = NewRandomString, Value = NewRandomInt64, BlockIndex = 100 };
+      var outpoint2 = new Outpoint { OutputIndex = NewRandomInt32, TransactionId = NewRandomString };
+      var unspentOutput2 = new UnspentOutputTable { Outpoint = outpoint2, Address = NewRandomString, Value = NewRandomInt64, BlockIndex = 100 };
+      var outpoint3 = new Outpoint { OutputIndex = NewRandomInt32, TransactionId = NewRandomString };
+      var unspentOutput3 = new UnspentOutputTable { Outpoint = outpoint3, Address = addressSecondery, Value = NewRandomInt64, BlockIndex = 100 };
+
+      mongodbMock.GivenTheDocumentIsReturnedSuccessfullyFromMongoDb(mongodbMock.unspentOutputTableCollection, unspentOutput1);
+      mongodbMock.GivenTheDocumentIsReturnedSuccessfullyFromMongoDb(mongodbMock.unspentOutputTableCollection, unspentOutput2);
+      mongodbMock.GivenTheDocumentIsReturnedSuccessfullyFromMongoDb(mongodbMock.unspentOutputTableCollection, unspentOutput3);
+
+
+      var mempoolTable = new MempoolTable
+      {
+         TransactionId = NewRandomString,
+      };
+
+      mempoolTable.Inputs.Add(new MempoolInput { Address = addressMain, Outpoint = outpoint1, Value = 5 });
+      mempoolTable.Inputs.Add(new MempoolInput { Address = addressSecondery, Outpoint = outpoint2, Value = 5 });
+      mempoolTable.Outputs.Add(new MempoolOutput { Address = addressMain, Value = 5 });
+      mempoolTable.Outputs.Add(new MempoolOutput { Address = addressSecondery, Value = 5 });
+
+      mongodbMock.GivenTheDocumentIsReturnedSuccessfullyFromMongoDb(mongodbMock.mempoolTable, mempoolTable);
+
+      var res = sut.GetUnspentTransactionsByAddressAsync(addressMain, 0, 0, 10).Result;
+   }
+}

--- a/src/Blockcore.Indexer.Tests/Storage/Mongo/MongodbMock.cs
+++ b/src/Blockcore.Indexer.Tests/Storage/Mongo/MongodbMock.cs
@@ -40,6 +40,7 @@ public class MongodbMock
       db.Setup(_ => _.UnspentOutputTable).Returns(unspentOutputTableCollection.Object);
       db.Setup(_ => _.InputTable).Returns(inputTableCollection.Object);
       db.Setup(_ => _.TransactionTable).Returns(transactionTable.Object);
+      db.Setup(_ => _.Mempool).Returns(mempoolTable.Object);
 
       mongodatabase = new Mock<IMongoDatabase>();
       mongodatabase.Setup(_ => _.GetCollection<BlockTable>("Block",null))
@@ -142,5 +143,59 @@ public class MongodbMock
       var serializerRegistry = BsonSerializer.SerializerRegistry;
       var documentSerializer = serializerRegistry.GetSerializer<TDocument>();
       return (documentSerializer, serializerRegistry);
+   }
+
+   public Mock<IAsyncCursor<AggregateCountResult>> GivenTheAggregateCountReturnsTheExpectesSet<T>(Mock<IMongoCollection<T>> collection, int countResult)
+   {
+      var countCursor = new Mock<IAsyncCursor<AggregateCountResult>>();
+
+      collection.Setup(_ =>
+            _.Aggregate(It.IsAny<AppendedStagePipelineDefinition<T, AggregateCountResult, AggregateCountResult>>(),
+               It.IsAny<AggregateOptions>(), It.IsAny<CancellationToken>()))
+         .Returns((AppendedStagePipelineDefinition<T, AggregateCountResult, AggregateCountResult> e, AggregateOptions o,
+            CancellationToken t) => countCursor.Object);
+
+      countCursor.SetupSequence(_ => _.MoveNext(It.IsAny<CancellationToken>()))
+         .Returns(true)
+         .Returns(false);
+
+      countCursor.Setup(_ => _.Current).Returns(new List<AggregateCountResult> { new AggregateCountResult(countResult) });
+
+      return countCursor;
+   }
+
+   public Mock<IAsyncCursor<T>> GivenTheAggregateListReturnsTheExpectedSet<T>(Mock<IMongoCollection<T>> collection, IEnumerable<T> returnedData)
+   {
+      var cursor = new Mock<IAsyncCursor<T>>();
+
+      collection.Setup(_ =>
+            _.Aggregate(It.IsAny<AppendedStagePipelineDefinition<T,T,T>>(), It.IsAny<AggregateOptions>(), It.IsAny<CancellationToken>()))
+         .Returns((AppendedStagePipelineDefinition<T,T,T> e,AggregateOptions o,CancellationToken t) => cursor.Object);
+
+      cursor.SetupSequence(_ => _.MoveNext(It.IsAny<CancellationToken>()))
+         .Returns(true)
+         .Returns(false);
+
+      cursor.Setup(_ => _.Current)
+         .Returns(returnedData);
+
+      return cursor;
+   }
+
+   public Mock<IAsyncCursor<T>> GivenTheAggregateListAsyncReturnsTheExpectedSet<T>(Mock<IMongoCollection<T>> collection, IEnumerable<T> returnedData)
+   {
+      var asyncCursor = new Mock<IAsyncCursor<T>>();
+
+      collection.Setup(_ =>
+            _.AggregateAsync(It.IsAny<AppendedStagePipelineDefinition<T,T,T>>(), It.IsAny<AggregateOptions>(), It.IsAny<CancellationToken>()))
+         .ReturnsAsync((AppendedStagePipelineDefinition<T,T,T> e,AggregateOptions o,CancellationToken t) => asyncCursor.Object);
+
+      asyncCursor.SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+         .ReturnsAsync(true)
+         .ReturnsAsync(false);
+
+      asyncCursor.Setup(_ => _.Current).Returns(returnedData);
+
+      return asyncCursor;
    }
 }

--- a/src/Blockcore.Indexer.Tests/Storage/Mongo/MongodbMock.cs
+++ b/src/Blockcore.Indexer.Tests/Storage/Mongo/MongodbMock.cs
@@ -18,6 +18,7 @@ public class MongodbMock
    public Mock<IMongoCollection<UnspentOutputTable>> unspentOutputTableCollection;
    public Mock<IMongoCollection<InputTable>> inputTableCollection;
    public Mock<IMongoCollection<TransactionTable>> transactionTable;
+   public Mock<IMongoCollection<MempoolTable>> mempoolTable;
 
    protected Mock<IMongoDatabase> mongodatabase;
    private readonly Mock<IMongoDb> db;
@@ -31,6 +32,7 @@ public class MongodbMock
       unspentOutputTableCollection = new Mock<IMongoCollection<UnspentOutputTable>>();
       inputTableCollection = new Mock<IMongoCollection<InputTable>>();
       transactionTable = new Mock<IMongoCollection<TransactionTable>>();
+      mempoolTable = new Mock<IMongoCollection<MempoolTable>>();
 
       db.Setup(_ => _.BlockTable).Returns(blockTableCollection.Object);
       db.Setup(_ => _.TransactionBlockTable).Returns(transactionBlockTableCollection.Object);
@@ -52,6 +54,8 @@ public class MongodbMock
          .Returns(inputTableCollection.Object);
       mongodatabase.Setup(_ => _.GetCollection<TransactionTable>("Transaction",null))
          .Returns(transactionTable.Object);
+      mongodatabase.Setup(_ => _.GetCollection<MempoolTable>("Mempool", null))
+         .Returns(mempoolTable.Object);
 
       mongodatabase.Setup(_ => _.Client)
          .Returns(new Mock<IMongoClient>().Object);


### PR DESCRIPTION
This should remove outputs that are currently spent in mempool form the api end point `address/{address}/transactions/unspent`
outputs that are spent should not return in that end point because they might be used again by the wallet when spending.

should we also add outputs that are new and not confirmed to the end point?